### PR TITLE
Add explicit reference to Zam for misaligned AMOs

### DIFF
--- a/zacas.adoc
+++ b/zacas.adoc
@@ -115,7 +115,8 @@ Just as for AMOs in the A extension, `AMOCAS.W/D/Q` requires that the address
 held in `rs1` be naturally aligned to the size of the operand (i.e., 16-byte
 aligned for 128-bit words, eight-byte aligned for 64-bit words, and four-byte
 aligned for 32-bit words). And the same exception options apply if the address
-is not naturally aligned.
+is not naturally aligned. The "Zam" extension relaxes this requirement and
+specifies the semantics of misaligned AMOs.
 
 Just as for AMOs in the A extension, the `AMOCAS.W/D/Q` optionally provide
 release consistency semantics, using the `aq` and `rl` bits, to help implement


### PR DESCRIPTION
I believe the intent is that Zam can be used with Zacas and has the same effect as for the 'A' extension. I've added a sentence to make this explicit. Perhaps "the same exception options apply if the address is not naturally aligned" is meant to encompass this, but it didn't seem obvious to me that it does.