### PR TITLE
Explicitly state that Zacas depends upon the A extension

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -78,5 +78,6 @@ quadword compare and swap (of both the pointer and the counter). The double and
 quadword CAS instructions support implementation of algorithms for ABA problem
 avoidance.
 
+The Zacas extension depends upon the A extension.
 
 include::zacas.adoc[]


### PR DESCRIPTION
This wasn't explicitly stated anywhere, but I assume it's intended.