### PR TITLE
Clarify amocas.w for RV64 and add a code sequence

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -1,5 +1,5 @@
 [[header]]
-:description: Atomic Compare-and-swap (CAS) instructions
+:description: Atomic Compare-and-Swap (CAS) instructions
 :company: RISC-V.org
 :revdate: 6/2023
 :revnumber: 1.0-rc1
@@ -33,7 +33,7 @@ endif::[]
 :footnote:
 :xrefstyle: short
 
-= Atomic Compare-and-swap (CAS) instructions (Zacas)
+= Atomic Compare-and-Swap (CAS) instructions (Zacas)
 
 // Preamble
 [WARNING]
@@ -61,7 +61,7 @@ Greg Favor, Ved Shanbhogue
 
 == Introduction
 
-Compare-and-swap (CAS) provides an easy and typically faster way to perform
+Compare-and-Swap (CAS) provides an easy and typically faster way to perform
 thread synchronization operations when supported as a hardware instruction. CAS
 is typically used by lock-free and wait-free algorithms. This extension proposes
 CAS instructions to operate on 32-bit, 64-bit, and 128-bit (RV64 only) data

--- a/header.adoc
+++ b/header.adoc
@@ -57,7 +57,7 @@ Copyright 2023 by RISC-V International.
 [preface]
 === Contributors
 This RISC-V specification has been contributed to directly or indirectly by:
-Greg Favor, Ved Shanbhogue
+Greg Favor, Ved Shanbhogue, Andrew Waterman
 
 == Introduction
 

--- a/zacas.adoc
+++ b/zacas.adoc
@@ -144,14 +144,12 @@ the two registers may be loaded using two individual loads. The two individual
 loads may read an inconsistent pair of values but that is not an issue since the
 `AMOCAS` operation itself uses an atomic load-pair from memory to obtain the
 data value for its comparison.
-=======
 
 The following code sequence illustrates a quadword compare-and-swap operation.
 The registers a6 and a7 that are used to source the compare data value are
 loaded using two individual loads. The registers a4 and a5 hold the swap data
 value. The register a0 holds the address of the memory location operated on by
 the instruction.
-
 [listing]
 ----
     # initialize the swap value
@@ -161,7 +159,6 @@ the instruction.
     # initialize the expected value
     li a2, expected_value0
     li a3, expected_value1
-
 retry:
     # load the current value
     ld a6, 0(a0)

--- a/zacas.adoc
+++ b/zacas.adoc
@@ -15,13 +15,11 @@
 ], config:{lanes: 1, hspace:1024}}
 ....
 
-`AMOCAS.W` atomically loads 32-bits of a data value from address in `rs1`,
-compares the loaded value to a 32-bit value held in `rd` and if the
-comparison is bitwise equal, then stores the 32-bit value held in `rs2` to
-the original address in `rs1`. The value loaded from memory is placed into
-register `rd`. For RV64, `AMOCAS.W` always sign-extends the value placed in
-`rd`, and ignores the upper 32 bits of the original value in `rd` and `rs2`.
-The operation performed by `AMOCAS.W` is as follows:
+For RV32, `AMOCAS.W` atomically loads a 32-bit data value from address in `rs1`,
+compares the loaded value to the 32-bit value held in `rd` and if the comparison
+is bitwise equal, then stores the 32-bit value held in `rs2` to the original
+address in `rs1`. The value loaded from memory is placed into register `rd`. The
+operation performed by `AMOCAS.W` for RV32 is as follows:
 
 [listing]
 ----
@@ -30,6 +28,22 @@ The operation performed by `AMOCAS.W` is as follows:
         *X[rs1] = X[rs2]
     endif
     X[rd] = temp
+----
+
+For RV64, `AMOCAS.W` atomically loads a 32-bit data value from address in
+`rs1`, compares the loaded value to the lower 32 bits of the value held in `rd`
+and if the comparison is bitwise equal, then stores the lower 32 bits of the
+value held in `rs2` to the original address in `rs1`. The 32-bit value loaded
+from memory is sign extended and is placed into register `rd`. The operation
+performed by `AMOCAS.W` for RV64 is as follows:
+
+[listing]
+----
+    temp[31:0] = *X[rs1]
+    if temp[31:0] == (X[rd])[31:0]
+        *X[rs1] = (X[rs2])[31:0]
+    endif
+    X[rd] = SignExtend(temp[31:0])
 ----
 
 `AMOCAS.D` is similar to `AMOCAS.W` but operates on 64-bit data values.
@@ -130,6 +144,38 @@ the two registers may be loaded using two individual loads. The two individual
 loads may read an inconsistent pair of values but that is not an issue since the
 `AMOCAS` operation itself uses an atomic load-pair from memory to obtain the
 data value for its comparison.
+<<<<<<< HEAD
+=======
+
+The following code sequence illustrates a quadword compare-and-swap operation.
+The registers t3 and t4 that are used to source the compare data value are
+loaded using two individual loads. The registers t5 and t6 hold the swap data
+value. The register a0 holds the address of the memory location operated on by
+the instruction.
+
+[listing]
+----
+   .section .data
+   pointer: .dword 0
+   count:   .dword 0
+   :
+   .section .text
+   :
+   la a0, pointer
+   ld t3, (a0)                # compare value 0 - "old" pointer
+   ld t4, 8(a0)               # compare value 1 - "old" count
+retry:                        # note: amocas reloads "old" values
+   :                          # into (t3, t4) to retry on failure
+   mv t2, t4                  # save count to check if failed
+   mv t5, t3                  # swap value 0 - expectred pointer
+   addi t6, t4, 1             # swap value 1 - updated count
+   amocas.q.aqrl t3, t5, (a0) # quadword compare and swap
+   bne t3, t5, retry          # retry if operation failed
+   bne t4, t2, retry          # retry if operation failed
+   :
+----
+
+>>>>>>> 882ecf4 (fixing typos)
 ====
 
 == Additional AMO PMAs

--- a/zacas.adoc
+++ b/zacas.adoc
@@ -144,38 +144,41 @@ the two registers may be loaded using two individual loads. The two individual
 loads may read an inconsistent pair of values but that is not an issue since the
 `AMOCAS` operation itself uses an atomic load-pair from memory to obtain the
 data value for its comparison.
-<<<<<<< HEAD
 =======
 
 The following code sequence illustrates a quadword compare-and-swap operation.
-The registers t3 and t4 that are used to source the compare data value are
-loaded using two individual loads. The registers t5 and t6 hold the swap data
+The registers a6 and a7 that are used to source the compare data value are
+loaded using two individual loads. The registers a4 and a5 hold the swap data
 value. The register a0 holds the address of the memory location operated on by
 the instruction.
 
 [listing]
 ----
-   .section .data
-   pointer: .dword 0
-   count:   .dword 0
-   :
-   .section .text
-   :
-   la a0, pointer
-   ld t3, (a0)                # compare value 0 - "old" pointer
-   ld t4, 8(a0)               # compare value 1 - "old" count
-retry:                        # note: amocas reloads "old" values
-   :                          # into (t3, t4) to retry on failure
-   mv t2, t4                  # save count to check if failed
-   mv t5, t3                  # swap value 0 - expectred pointer
-   addi t6, t4, 1             # swap value 1 - updated count
-   amocas.q.aqrl t3, t5, (a0) # quadword compare and swap
-   bne t3, t5, retry          # retry if operation failed
-   bne t4, t2, retry          # retry if operation failed
-   :
+    # initialize the swap value
+    li a4, new_value0
+    li a5, new_value1
+
+    # initialize the expected value
+    li a2, expected_value0
+    li a3, expected_value1
+
+retry:
+    # load the current value
+    ld a6, 0(a0)
+    ld a7, 8(a0)
+
+    # retry if current value not the expected value
+    bne a6, a2, retry
+    bne a7, a3, retry
+
+    # quadword compare and swap
+    amocas.q.aqrl a6, a4, (a0)
+
+    # retry if CAS failed
+    bne a6, a2, retry
+    bne a7, a3, retry
 ----
 
->>>>>>> 882ecf4 (fixing typos)
 ====
 
 == Additional AMO PMAs

--- a/zacas.adoc
+++ b/zacas.adoc
@@ -23,11 +23,11 @@ operation performed by `AMOCAS.W` for RV32 is as follows:
 
 [listing]
 ----
-    temp = *X[rs1]
-    if temp == X[rd]
-        *X[rs1] = X[rs2]
+    temp = mem[X(rs1)]
+    if ( temp == X(rd) )
+        mem[X(rs1)] = X(rs2)
     endif
-    X[rd] = temp
+    X(rd) = temp
 ----
 
 For RV64, `AMOCAS.W` atomically loads a 32-bit data value from address in
@@ -39,11 +39,11 @@ performed by `AMOCAS.W` for RV64 is as follows:
 
 [listing]
 ----
-    temp[31:0] = *X[rs1]
-    if temp[31:0] == (X[rd])[31:0]
-        *X[rs1] = (X[rs2])[31:0]
+    temp[31:0] = mem[X(rs1)]
+    if ( temp[31:0] == X(rd)[31:0] )
+        mem[X(rs1)] = X(rs2)[31:0]
     endif
-    X[rd] = SignExtend(temp[31:0])
+    X(rd) = SignExtend(temp[31:0])
 ----
 
 `AMOCAS.D` is similar to `AMOCAS.W` but operates on 64-bit data values.
@@ -62,19 +62,19 @@ result is discarded and neither destination register is written.
 The operation performed by `AMOCAS.D` for RV32 is as follows:
 [listing]
 ----
-    temp0 = *(X[rs1]+0)
-    temp1 = *(X[rs1]+4)
-    comp0 = (rd == x0)  ? 0 : X[rd]
-    comp1 = (rd == x0)  ? 0 : X[rd+1]
-    swap0 = (rs2 == x0) ? 0 : X[rs2]
-    swap1 = (rs2 == x0) ? 0 : X[rs2+1]
-    if (temp0 == comp0) && (temp1 == comp1)
-        *(X[rs1]+0) = swap0
-        *(X[rs1]+4) = swap1
+    temp0 = mem[X(rs1)+0]
+    temp1 = mem[X(rs1)+4]
+    comp0 = (rd == x0)  ? 0 : X(rd)
+    comp1 = (rd == x0)  ? 0 : X(rd+1)
+    swap0 = (rs2 == x0) ? 0 : X(rs2)
+    swap1 = (rs2 == x0) ? 0 : X(rs2+1)
+    if ( temp0 == comp0 ) && ( temp1 == comp1 )
+        mem[X(rs1)+0] = swap0
+        mem[X(rs1)+4] = swap1
     endif
     if ( rd != x0 )
-        X[rd]   = temp0
-        X[rd+1] = temp1
+        X(rd)   = temp0
+        X(rd+1) = temp1
     endif
 ----
 
@@ -85,11 +85,11 @@ original address in `rs1`. The value loaded from memory is placed into register
 `rd`. The operation performed by `AMOCAS.D` for RV64 is as follows:
 [listing]
 ----
-    temp = *X[rs1]
-    if temp == X[rd]
-        *X[rs1] = X[rs2]
+    temp = mem[X(rs1)]
+    if ( temp == X(rd) )
+        mem[X(rs1)] = X(rs2)
     endif
-    X[rd] = temp
+    X(rd) = temp
 ----
 `AMOCAS.Q` (RV64 only) atomically loads 128-bits of a data value from address in
 `rs1`, compares the loaded value to a 128-bit value held in a register pair
@@ -105,19 +105,19 @@ and neither destination register is written. The operation performed by
 `AMOCAS.Q` is as follows:
 [listing]
 ----
-    temp0 = *(X[rs1]+0)
-    temp1 = *(X[rs1]+8)
-    comp0 = (rd == x0)  ? 0 : X[rd]
-    comp1 = (rd == x0)  ? 0 : X[rd+1]
-    swap0 = (rs2 == x0) ? 0 : X[rs2]
-    swap1 = (rs2 == x0) ? 0 : X[rs2+1]
-    if (temp0 == comp0) && (temp1 == comp1)
-        *(X[rs1]+0) = swap0
-        *(X[rs1]+8) = swap1
+    temp0 = mem[X(rs1)+0]
+    temp1 = mem[X(rs1)+8]
+    comp0 = (rd == x0)  ? 0 : X(rd)
+    comp1 = (rd == x0)  ? 0 : X(rd+1)
+    swap0 = (rs2 == x0) ? 0 : X(rs2)
+    swap1 = (rs2 == x0) ? 0 : X(rs2+1)
+    if ( temp0 == comp0 ) && ( temp1 == comp1 )
+        mem[X(rs1)+0] = swap0
+        mem[X(rs1)+8] = swap1
     endif
     if ( rd != x0 )
-        X[rd]   = temp0
-        X[rd+1] = temp1
+        X(rd)   = temp0
+        X(rd+1) = temp1
     endif
 ----
 [NOTE]


### PR DESCRIPTION
1, Add a clearer explanation that only low 32 bits are used in compare for rv64
2. Add assembler example to suggest assembler syntax