### PR TITLE
Update document version (semi-automatically)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # the Doc Template for RISC-V Extensions.
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v0.0.0
-REVMARK ?= Draft
+VERSION ?= $(shell git describe --tag --always --dirty)
+REVMARK ?= Frozen
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
 riscvintl/riscv-docs-base-container-image:latest
 


### PR DESCRIPTION
Though the documentation is now v1.0-rc5, the documentation itself says it's still version 0.0.0 and still in Draft.

This PR partially introduces a technique from riscv/riscv-zicond.  Even if this PR is not suitable for your repository, I hope that the documentation is properly versioned.